### PR TITLE
Fix: Unable to collect changes

### DIFF
--- a/tc/project.go
+++ b/tc/project.go
@@ -71,7 +71,7 @@ func CancelBuild(config config.Config, build int) error {
 func LastBuild(config config.Config, build string) (*Build, error) {
 	req, err := http.NewRequest(
 		http.MethodGet,
-		fmt.Sprintf("%s/app/rest/builds?locator=buildType:(id:%s),branch:default:any,running:any", config.URL, build),
+		fmt.Sprintf("%s/app/rest/builds?locator=buildType:(id:%s),branch:default:any,running:any,defaultFilter:false", config.URL, build),
 		nil,
 	)
 	if err != nil {


### PR DESCRIPTION
Builds failing to start are now correctly marked as failed.

closes #8