### PR TITLE
Updates workflow CI

### DIFF
--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -84,9 +84,6 @@ func suggestFromTags(tags []string) string {
 		if validVersions[i].Patch < validVersions[j].Patch {
 			return true
 		}
-		if validVersions[i].Patch > validVersions[j].Patch {
-			return false
-		}
 		return false
 	})
 

--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"strconv"
+
+	"github.com/fatih/color"
+	"github.com/molotovtv/tc/internal/config"
+	"github.com/molotovtv/tc/internal/git"
+	"github.com/molotovtv/tc/tc"
+	"github.com/spf13/cobra"
+)
+
+var (
+	tagRegex = regexp.MustCompile("^v([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+)
+
+func init() {
+	RootCmd.AddCommand(pkgCmd)
+}
+
+type version struct {
+	Tag   string
+	Major int
+	Minor int
+	Patch int
+}
+
+func versionFromTag(tag string) *version {
+	matches := tagRegex.FindAllStringSubmatch(tag, -1)
+	if len(matches) > 0 && len(matches[0]) == 4 {
+		major, err := strconv.Atoi(matches[0][1])
+		if err != nil {
+			return nil
+		}
+		minor, err := strconv.Atoi(matches[0][2])
+		if err != nil {
+			return nil
+		}
+		patch, err := strconv.Atoi(matches[0][3])
+		if err != nil {
+			return nil
+		}
+		return &version{
+			Tag:   tag,
+			Major: major,
+			Minor: minor,
+			Patch: patch,
+		}
+	}
+	return nil
+}
+
+func suggestFromTags(tags []string) string {
+	// filter only valid tags
+	validVersions := []*version{}
+	for _, tag := range tags {
+		if v := versionFromTag(tag); v != nil {
+			validVersions = append(validVersions, v)
+		}
+	}
+
+	if len(validVersions) == 0 {
+		return "v1.0.0" // suggest v1.0.0 if no other idea
+	}
+
+	// sort by version
+	sort.Slice(validVersions, func(i, j int) bool {
+		if validVersions[i].Major < validVersions[j].Major {
+			return true
+		}
+		if validVersions[i].Major > validVersions[j].Major {
+			return false
+		}
+		if validVersions[i].Minor < validVersions[j].Minor {
+			return true
+		}
+		if validVersions[i].Minor > validVersions[j].Minor {
+			return false
+		}
+		if validVersions[i].Patch < validVersions[j].Patch {
+			return true
+		}
+		if validVersions[i].Patch > validVersions[j].Patch {
+			return false
+		}
+		return false
+	})
+
+	return fmt.Sprintf("v%d.%d.%d", validVersions[len(validVersions)-1].Major, validVersions[len(validVersions)-1].Minor, validVersions[len(validVersions)-1].Patch+1)
+}
+
+var pkgCmd = &cobra.Command{
+	Use:   "pkg",
+	Short: "Package a tag",
+	Args:  cobra.MinimumNArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		tag := ""
+		if len(args) > 0 {
+			tag = args[0]
+		} else {
+			tags, err := git.CurrentTags()
+			if err != nil {
+				log.Fatalf("%+v", err)
+				return
+			}
+			if len(tags) == 0 {
+				tags, err := git.Tags()
+				if err != nil {
+					log.Fatalf("%+v", err)
+					return
+				}
+				suggestedTag := suggestFromTags(tags)
+				fmt.Printf("No tag found in HEAD. Suggested tag : %s ; create ?", suggestedTag)
+				var ok string
+				fmt.Scanln(&ok)
+				if err := git.CreateTagAndPush(suggestedTag); err != nil {
+					log.Fatalf("%+v", err)
+					return
+				}
+				tag = suggestedTag
+			} else if len(tags) > 1 {
+				log.Fatalf("more than one tag available, precise which one to package: %+v", tags)
+				return
+			} else {
+				tag = tags[0]
+			}
+		}
+
+		if !tagRegex.Match([]byte(tag)) {
+			log.Fatalf("tag %s does not validate, tags for packaging must be vx.y.z", tag)
+			return
+		}
+		c, err := config.Load()
+		if err != nil {
+			log.Fatalf("%+v", err)
+		}
+		buildTypeID, err := config.BuildTypeID("packaging")
+		if err != nil {
+			log.Fatalf("%+v", err)
+		}
+		fmt.Printf("Starting packaging version %s...\n", color.New(color.FgGreen).SprintFunc()(tag))
+		buildID, err := tc.RunBranch(c, buildTypeID, tag)
+		if err != nil {
+			log.Fatalf("%+v", err)
+		}
+
+		if runSilent {
+			return
+		}
+
+		buildStatus(c, buildID)
+	},
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -80,13 +80,13 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("%+v", err)
 		}
-		if env == "prod" {
+		if env == "prod" || env == "test" {
 			refInfos, err := git.ShowRef(tag)
 			if err != nil {
 				log.Fatalf("%+v", err)
 			}
 			branch = branch[1:len(branch)]
-			fmt.Printf("Will deploy version (%s) with this commit to %s\n------------------------------\n%s\n------------------------------\nContinue?", color.New(color.FgGreen).SprintFunc()(branch), color.New(color.Bold).SprintFunc()("prod"), refInfos)
+			fmt.Printf("Will deploy version (%s) with this commit to %s\n------------------------------\n%s\n------------------------------\nContinue?", color.New(color.FgGreen).SprintFunc()(branch), color.New(color.Bold).SprintFunc()(env), refInfos)
 			var ok string
 			fmt.Scanln(&ok)
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -71,8 +71,6 @@ var runCmd = &cobra.Command{
 			branch = tag
 		}
 
-		fmt.Println("Branch:", branch)
-
 		c, err := config.Load()
 		if err != nil {
 			log.Fatalf("%+v", err)
@@ -87,7 +85,8 @@ var runCmd = &cobra.Command{
 			if err != nil {
 				log.Fatalf("%+v", err)
 			}
-			fmt.Printf("Will deploy this commit to %s\n------------------------------\n%s\n------------------------------\nContinue?", color.New(color.Bold).SprintFunc()("prod"), refInfos)
+			branch = branch[1:len(branch)]
+			fmt.Printf("Will deploy version (%s) with this commit to %s\n------------------------------\n%s\n------------------------------\nContinue?", color.New(color.FgGreen).SprintFunc()(branch), color.New(color.Bold).SprintFunc()("prod"), refInfos)
 		}
 		var ok string
 		fmt.Scanln(&ok)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -87,9 +87,9 @@ var runCmd = &cobra.Command{
 			}
 			branch = branch[1:len(branch)]
 			fmt.Printf("Will deploy version (%s) with this commit to %s\n------------------------------\n%s\n------------------------------\nContinue?", color.New(color.FgGreen).SprintFunc()(branch), color.New(color.Bold).SprintFunc()("prod"), refInfos)
+			var ok string
+			fmt.Scanln(&ok)
 		}
-		var ok string
-		fmt.Scanln(&ok)
 		fmt.Printf("Deploying version %s on %s...\n", color.New(color.FgGreen).SprintFunc()(branch), color.New(color.FgGreen).SprintFunc()(env))
 
 		buildID, err := tc.RunBranch(c, buildTypeID, branch)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 
+	"github.com/fatih/color"
 	"github.com/molotovtv/tc/tc"
 
 	"github.com/molotovtv/tc/internal/config"
@@ -32,23 +33,42 @@ func renameBranchForProd(branchOrigin string) string {
 
 var runCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Run a build",
+	Short: "Deploy a version",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		env := args[0]
 
 		fmt.Println("Env:", env)
-
-		branch, err := git.Branch()
+		var tag string
+		branch, err := git.CurrentBranch()
 		if err != nil {
 			log.Fatalf("%+v", err)
 		}
 		if env == "prod" || env == "test" {
-			prodBranch := renameBranchForProd(branch)
-			if branch == "" {
-				log.Fatalf("could not remap branch %s to a correct prod branch name", branch)
+			if len(args) > 1 {
+				tag = args[1]
+			} else {
+				tags, err := git.CurrentTags()
+				if err != nil {
+					log.Fatalf("%+v", err)
+					return
+				}
+				if len(tags) == 0 {
+					log.Fatalf("No tag found in HEAD. precise which tag to run.")
+					return
+				} else if len(tags) > 1 {
+					log.Fatalf("more than one tag available, precise which one to package: %+v", tags)
+					return
+				} else {
+					tag = tags[0]
+				}
 			}
-			branch = prodBranch
+
+			if !tagRegex.Match([]byte(tag)) {
+				log.Fatalf("tag %s does not validate, tags for prod must be vx.y.z", tag)
+				return
+			}
+			branch = tag
 		}
 
 		fmt.Println("Branch:", branch)
@@ -62,6 +82,16 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("%+v", err)
 		}
+		if env == "prod" {
+			refInfos, err := git.ShowRef(tag)
+			if err != nil {
+				log.Fatalf("%+v", err)
+			}
+			fmt.Printf("Will deploy this commit to %s\n------------------------------\n%s\n------------------------------\nContinue?", color.New(color.Bold).SprintFunc()("prod"), refInfos)
+		}
+		var ok string
+		fmt.Scanln(&ok)
+		fmt.Printf("Deploying version %s on %s...\n", color.New(color.FgGreen).SprintFunc()(branch), color.New(color.FgGreen).SprintFunc()(env))
 
 		buildID, err := tc.RunBranch(c, buildTypeID, branch)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c h1:fyKiXKO1/I/B6Y2U8T7WdQGWzwehOuGIrljPtt7YTTI=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -5,10 +5,80 @@ import (
 	"strings"
 )
 
-func Branch() (string, error) {
+func ShowRef(ref string) (string, error) {
+	out, err := exec.Command("git", "show", "--pretty=medium", "--quiet", ref).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// CurrentBranch returns the current branch name
+func CurrentBranch() (string, error) {
 	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// CurrentCommit returns the current commit hash
+func CurrentCommit() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// CurrentTags returns tags pointing to current commit
+func CurrentTags() ([]string, error) {
+	err := exec.Command("git", "fetch", "--tags").Run()
+	if err != nil {
+		return nil, err
+	}
+	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		return nil, err
+	}
+	currentCommit := strings.TrimSpace(string(out))
+	out, err = exec.Command("git", "tag", "--points-at", currentCommit).Output()
+	if err != nil {
+		return nil, err
+	}
+	tags := []string{}
+	for _, tag := range strings.Split(string(out), "\n") {
+		tag = strings.TrimSpace(tag)
+		if len(tag) > 0 {
+			tags = append(tags, tag)
+		}
+	}
+	return tags, nil
+}
+
+// Tags returns all tags
+func Tags() ([]string, error) {
+	err := exec.Command("git", "fetch", "--tags").Run()
+	if err != nil {
+		return nil, err
+	}
+	out, err := exec.Command("git", "tag").Output()
+	if err != nil {
+		return nil, err
+	}
+	tags := []string{}
+	for _, tag := range strings.Split(string(out), "\n") {
+		tag = strings.TrimSpace(tag)
+		if len(tag) > 0 {
+			tags = append(tags, tag)
+		}
+	}
+	return tags, nil
+}
+
+func CreateTagAndPush(tag string) error {
+	if err := exec.Command("git", "tag", tag).Run(); err != nil {
+		return err
+	}
+	return exec.Command("git", "push", "--tags").Run()
 }


### PR DESCRIPTION
This PR adds and modifies some stuff for new CI workflow.

Changed :
tc run prod does not recompute branch anymore but can take a tag arg or not.

If no tag is specified, tc finds current tags matching semver in HEAD. If 1 and exactly 1 is found, it proposes to deploy this tag in prod :

```
➜  go-shelf-service git:(dev) ✗ tc run prod
Env: prod
Branch: v1.0.18
Will deploy this commit to prod
------------------------------
commit c7896a8948ebdb3dea35a5f0481b110ed1da6b75
Author: Eric Renard <erenard@molotov.tv>
Date:   Thu Aug 22 22:54:17 2019 +0200

    update tc

------------------------------
Continue?
```

If no tag is found or more than one tag found, command fail.
If a tag is specified, it tries to deploy this one :

```
➜  go-shelf-service git:(dev) ✗ tc run prod v1.0.17
Env: prod
Branch: v1.0.17
Will deploy this commit to prod
------------------------------
commit 733bb2d7a1655d69e8aa66c00a6acce96da8f06c
Author: Eric Renard <erenard@molotov.tv>
Date:   Thu Aug 22 22:39:11 2019 +0200

    add tc

------------------------------
Continue?
```

Added :
There's a new command "pkg" to build a package from a tag.
If a tag is specified, tc will run packaging for this tag (e.g. tc pkg v1.0.0)

If no tags are specified, tc looks for current tags in HEAD. 
If there is exactly one tag in current HEAD, tc runs this one.
If there is more than one tag in current HEAD, tc fails and asks for precision.
If there is 0 tags in current HEAD, tc fetches current tags for the repo and suggests a new tag (takes last version found and adds 1 to patch version). If confirmed, tc creates this tag, pushes it and packages the version.